### PR TITLE
Improve: simplify some MMCPServer methods

### DIFF
--- a/src/MMCPServer.cpp
+++ b/src/MMCPServer.cpp
@@ -134,7 +134,7 @@ QPair<bool, QString> MMCPServer::call(const QString& line)
     if (n < 1) {
         const QString infoMsg = tr("[ CHAT ]  - You must specify a host.");
         mpHost->postMessage(infoMsg);
-        return QPair<bool, QString>(false, qsl("must specify a host"));
+        return {false, qsl("must specify a host")};
     }
 
     quint16 port = 4050;
@@ -146,7 +146,7 @@ QPair<bool, QString> MMCPServer::call(const QString& line)
     }
 
     call(args[0], port);
-    return QPair<bool, QString>(true, qsl("command successful"));
+    return {true, QString()};
 }
 
 /**
@@ -170,7 +170,7 @@ QPair<bool, QString> MMCPServer::call(const QString& host, int port)
         const QString infoMsg = tr("[ CHAT ]  - Already connected to %1:%2.").arg(host).arg(port);
         mpHost->postMessage(infoMsg);
 
-        return QPair<bool, QString>(false, qsl("already connected to that client"));
+        return {false, qsl("already connected to that client")};
     }
 
     const QString infoMsg = tr("[ CHAT ]  - Connecting to %1:%2...").arg(host).arg(port);
@@ -180,7 +180,7 @@ QPair<bool, QString> MMCPServer::call(const QString& host, int port)
 
     client->tryConnect(host, port);
 
-    return QPair<bool, QString>(true, qsl("command successful"));
+    return {true, QString()};
 }
 
 
@@ -201,12 +201,12 @@ QPair<bool, QString> MMCPServer::chat(const QVariant& target, const QString& msg
         client->writeData(outMsg);
 
         clientMessage(QString("You chat to %1, '%2'").arg(client->chatName()).arg(msg));
-        return QPair<bool, QString>(true, qsl("command successful"));
+        return {true, QString()};
     }
 
     const QString infoMsg = tr("[ CHAT ]  - Invalid client id '%1'.").arg(target.toString());
     mpHost->postMessage(infoMsg);
-    return QPair<bool, QString>(false, qsl("no client by that name or id"));
+    return {false, qsl("no client by that name or id")};
 }
 
 
@@ -216,7 +216,7 @@ QPair<bool, QString> MMCPServer::chat(const QVariant& target, const QString& msg
 QPair<bool, QString> MMCPServer::chatAll(const QString& msg)
 {
     if (clients.isEmpty()) {
-        return QPair<bool, QString>(false, qsl("no connected clients"));
+        return {false, qsl("no connected clients")};
     }
 
     QString outMsg = QString("%1\n%2 chats to everybody, '%3'%4%5")
@@ -233,7 +233,7 @@ QPair<bool, QString> MMCPServer::chatAll(const QString& msg)
 
     clientMessage(QString("You chat to everybody, '%1'").arg(msg));
 
-    return QPair<bool, QString>(true, qsl("command successful"));
+    return {true, QString()};
 }
 
 /**
@@ -242,7 +242,7 @@ QPair<bool, QString> MMCPServer::chatAll(const QString& msg)
 QPair<bool, QString> MMCPServer::chatGroup(const QString& group, const QString& message)
 {
     if (clients.isEmpty()) {
-        return QPair<bool, QString>(false, qsl("no connected clients"));
+        return {false, qsl("no connected clients")};
     }
 
     using namespace AnsiColors;
@@ -267,7 +267,7 @@ QPair<bool, QString> MMCPServer::chatGroup(const QString& group, const QString& 
                             .arg(FBLDCYN).arg(group).arg(FBLDRED)
                             .arg(message));
 
-    return QPair<bool, QString>(true, qsl("command successful"));
+    return {true, QString()};
 }
 
 /**
@@ -300,7 +300,7 @@ QPair<bool, QString> MMCPServer::chatList()
 
     clientMessage(strMessage);
 
-    return QPair<bool, QString>(true, qsl("command successful"));
+    return {true, QString()};
 }
 
 /**
@@ -326,7 +326,7 @@ QPair<bool, QString> MMCPServer::chatName(const QString& name)
     const QString infoMsg = tr("[ CHAT ]  - You are now known as %1.").arg(name);
     mpHost->postMessage(infoMsg);
 
-    return QPair<bool, QString>(true, qsl("command successful"));
+    return {true, QString()};
 }
 
 /**
@@ -335,7 +335,7 @@ QPair<bool, QString> MMCPServer::chatName(const QString& name)
 QPair<bool, QString> MMCPServer::chatSideChannel(const QString& channel, const QString& msg)
 {
     if (clients.isEmpty()) {
-        return QPair<bool, QString>(false, qsl("no connected clients"));
+        return {false, qsl("no connected clients")};
     }
 
     const QString outMsg = QString("%1[%2]%3%4")
@@ -353,7 +353,7 @@ QPair<bool, QString> MMCPServer::chatSideChannel(const QString& channel, const Q
         }
     }
 
-    return QPair<bool, QString>(true, qsl("command successful"));
+    return {true, QString()};
 }
 
 
@@ -364,7 +364,7 @@ QPair<bool, QString> MMCPServer::chatSideChannel(const QString& channel, const Q
 QPair<bool, QString> MMCPServer::chatRaw(const QString& msg)
 {
     if (clients.isEmpty()) {
-        return QPair<bool, QString>(false, qsl("no connected clients"));
+        return {false, qsl("no connected clients")};
     }
 
     const QString outMsg = QString("%1%2%3")
@@ -380,7 +380,7 @@ QPair<bool, QString> MMCPServer::chatRaw(const QString& msg)
 
     clientMessage(msg);
 
-    return QPair<bool, QString>(true, qsl("command successful"));
+    return {true, QString()};
 }
 
 
@@ -405,12 +405,12 @@ QPair<bool, QString> MMCPServer::chatSetGroup(const QVariant& target, const QStr
         }
 
         mpHost->postMessage(infoMsg);
-        return QPair<bool, QString>(true, qsl("command successful"));
+        return {true, QString()};
     }
 
     const QString infoMsg = tr("[ CHAT ]  - Invalid client id '%1'.").arg(target.toString());
     mpHost->postMessage(infoMsg);
-    return QPair<bool, QString>(false, qsl("no client by that name or id"));
+    return {false, qsl("no client by that name or id")};
 }
 
 /**
@@ -419,7 +419,7 @@ QPair<bool, QString> MMCPServer::chatSetGroup(const QVariant& target, const QStr
 QPair<bool, QString> MMCPServer::emoteAll(const QString& msg)
 {
     if (clients.isEmpty()) {
-        return QPair<bool, QString>(false, qsl("no connected clients"));
+        return {false, qsl("no connected clients")};
     }
 
     const QString outMsg = QString("%1%2\n%3")
@@ -435,7 +435,7 @@ QPair<bool, QString> MMCPServer::emoteAll(const QString& msg)
 
     clientMessage(msg);
 
-    return QPair<bool, QString>(true, qsl("command successful"));
+    return {true, QString()};
 }
 
 /**
@@ -454,13 +454,13 @@ QPair<bool, QString> MMCPServer::ignore(const QString& target)
             mpHost->postMessage(infoMsg);
         }
         client->setIgnore(!client->isIgnored());
-        return QPair<bool, QString>(true, qsl("command successful"));
+        return {true, QString()};
     }
 
     const QString infoMsg = tr("[ CHAT ]  - Cannot find client identified by '%1'.").arg(target);
     mpHost->postMessage(infoMsg);
 
-    return QPair<bool, QString>(false, qsl("no client by that name or id"));
+    return {false, qsl("no client by that name or id")};
 }
 
 /**
@@ -472,10 +472,10 @@ QPair<bool, QString> MMCPServer::ping(const QVariant& target)
 
     if (client != nullptr) {
         client->sendPingRequest();
-        return QPair<bool, QString>(true, qsl("command successful"));
+        return {true, QString()};
     }
 
-    return QPair<bool, QString>(false, qsl("no client by that name or id"));
+    return {false, qsl("no client by that name or id")};
 }
 
 /**
@@ -487,10 +487,10 @@ QPair<bool, QString> MMCPServer::peek(const QVariant& target)
 
     if (client != nullptr) {
         client->sendPeekRequest();
-        return QPair<bool, QString>(true, qsl("command successful"));
+        return {true, QString()};
     }
 
-    return QPair<bool, QString>(false, qsl("no client by that name or id"));
+    return {false, qsl("no client by that name or id")};
 }
 
 /**
@@ -510,10 +510,10 @@ QPair<bool, QString> MMCPServer::chatPrivate(const QVariant& target)
             const QString infoMsg = tr("[ CHAT ]  - %1 is now set as private.").arg(client->chatName());
             mpHost->postMessage(infoMsg);
         }
-        return QPair<bool, QString>(true, qsl("command successful"));
+        return {true, QString()};
     }
 
-    return QPair<bool, QString>(false, qsl("no client by that name or id"));
+    return {false, qsl("no client by that name or id")};
 }
 
 /**
@@ -539,10 +539,10 @@ QPair<bool, QString> MMCPServer::serve(const QVariant& target)
             mpHost->postMessage(infoMsg);
         }
 
-        return QPair<bool, QString>(true, qsl("command successful"));
+        return {true, QString()};
     }
 
-    return QPair<bool, QString>(false, qsl("no client by that name or id"));
+    return {false, qsl("no client by that name or id")};
 }
 
 /**
@@ -553,14 +553,14 @@ QPair<bool, QString> MMCPServer::startServer(quint16 port)
     if (!listen(QHostAddress::Any, port)) {
         const QString infoMsg = tr("[ CHAT ]  - Unable to start server: %1.").arg(errorString());
         mpHost->postMessage(infoMsg);
-        return QPair<bool, QString>(false, qsl("unable to start server"));
+        return {false, qsl("unable to start server")};
     }
 
     const QString infoMsg = tr("[ CHAT ]  - Started server on port %1.").arg(port);
     mpHost->postMessage(infoMsg);
     emit serverStarted(port);
 
-    return QPair<bool, QString>(true, qsl("command successful"));
+    return {true, QString()};
 }
 
 /**
@@ -570,10 +570,10 @@ QPair<bool, QString> MMCPServer::stopServer()
 {
     if (isListening()) {
         close();
-        return QPair<bool, QString>(true, qsl("command successful"));
+        return {true, QString()};
     }
 
-    return QPair<bool, QString>(false, qsl("unable to stop server, it is not listening"));
+    return {false, qsl("unable to stop server, it is not listening")};
 }
 
 
@@ -601,10 +601,10 @@ QPair<bool, QString> MMCPServer::allowSnoop(const QVariant& target)
             mpHost->postMessage(infoMsg);
         }
 
-        return QPair<bool, QString>(true, qsl("command successful"));
+        return {true, QString()};
     }
 
-    return QPair<bool, QString>(false, qsl("no client by that name"));
+    return {false, qsl("no client by that name")};
 }
 
 /**
@@ -621,10 +621,10 @@ QPair<bool, QString> MMCPServer::snoop(const QVariant& target)
             client->snoop();
         }
 
-        return QPair<bool, QString>(true, qsl("command successful"));
+        return {true, QString()};
     }
 
-    return QPair<bool, QString>(false, qsl("no client by that name"));
+    return {false, qsl("no client by that name")};
 }
 
 /**
@@ -636,10 +636,10 @@ QPair<bool, QString> MMCPServer::unChat(const QVariant& target)
 
     if (client != NULL) {
         client->disconnect();
-        return QPair<bool, QString>(true, qsl("command successful"));
+        return {true, QString()};
     }
 
-    return QPair<bool, QString>(false, qsl("no client by that name"));
+    return {false, qsl("no client by that name")};
 }
 
 

--- a/src/TLuaInterpreterMMCP.cpp
+++ b/src/TLuaInterpreterMMCP.cpp
@@ -34,8 +34,7 @@ int TLuaInterpreter::chat(lua_State* L)
         pHost->initMMCPServer();
     }
 
-    QPair<bool, QString> const result = pHost->mmcpServer->chat(target, msg);
-
+    const auto result = pHost->mmcpServer->chat(target, msg);
     if (!result.first) {
         return warnArgumentValue(L, __func__, result.second.toUtf8().constData());
     }
@@ -53,8 +52,7 @@ int TLuaInterpreter::chatAll(lua_State* L)
         pHost->initMMCPServer();
     }
 
-    QPair<bool, QString> const result = pHost->mmcpServer->chatAll(msg);
-
+    const auto result = pHost->mmcpServer->chatAll(msg);
     if (!result.first) {
         return warnArgumentValue(L, __func__, result.second.toUtf8().constData());
     }
@@ -72,8 +70,7 @@ int TLuaInterpreter::chatAllowSnoop(lua_State* L)
         pHost->initMMCPServer();
     }
 
-    QPair<bool, QString> const result = pHost->mmcpServer->allowSnoop(target);
-
+    const auto result = pHost->mmcpServer->allowSnoop(target);
     if (!result.first) {
         return warnArgumentValue(L, __func__, result.second.toUtf8().constData());
     }
@@ -100,8 +97,7 @@ int TLuaInterpreter::chatCall(lua_State* L)
         pHost->initMMCPServer();
     }
 
-    QPair<bool, QString> const result = pHost->mmcpServer->call(host, port);
-
+    const auto result = pHost->mmcpServer->call(host, port);
     if (!result.first) {
         return warnArgumentValue(L, __func__, result.second.toUtf8().constData());
     }
@@ -119,8 +115,7 @@ int TLuaInterpreter::chatEmoteAll(lua_State* L)
         pHost->initMMCPServer();
     }
 
-    QPair<bool, QString> const result = pHost->mmcpServer->emoteAll(msg);
-
+    const auto result = pHost->mmcpServer->emoteAll(msg);
     if (!result.first) {
         return warnArgumentValue(L, __func__, result.second.toUtf8().constData());
     }
@@ -139,8 +134,7 @@ int TLuaInterpreter::chatGroup(lua_State* L)
         pHost->initMMCPServer();
     }
 
-    QPair<bool, QString> const result = pHost->mmcpServer->chatGroup(group, msg);
-
+    const auto result = pHost->mmcpServer->chatGroup(group, msg);
     if (!result.first) {
         return warnArgumentValue(L, __func__, result.second.toUtf8().constData());
     }
@@ -158,8 +152,7 @@ int TLuaInterpreter::chatIgnore(lua_State* L)
         pHost->initMMCPServer();
     }
 
-    QPair<bool, QString> const result = pHost->mmcpServer->ignore(target);
-
+    const auto result = pHost->mmcpServer->ignore(target);
     if (!result.first) {
         return warnArgumentValue(L, __func__, result.second.toUtf8().constData());
     }
@@ -175,8 +168,7 @@ int TLuaInterpreter::chatList(lua_State* L)
         pHost->initMMCPServer();
     }
 
-    QPair<bool, QString> const result = pHost->mmcpServer->chatList();
-
+    const auto result = pHost->mmcpServer->chatList();
     if (!result.first) {
         return warnArgumentValue(L, __func__, result.second.toUtf8().constData());
     }
@@ -193,11 +185,10 @@ int TLuaInterpreter::chatName(lua_State* L)
     }
 
     const int n = lua_gettop(L);
-    QPair<bool, QString> result;
     QString name;
     if (n > 0) {
         name = getVerifiedString(L, __func__, 1, "name");
-        result = pHost->mmcpServer->chatName(name);
+        const auto result = pHost->mmcpServer->chatName(name);
         if (!result.first) {
             return warnArgumentValue(L, __func__, result.second.toUtf8().constData());
         }
@@ -220,8 +211,7 @@ int TLuaInterpreter::chatPing(lua_State* L)
         pHost->initMMCPServer();
     }
 
-    QPair<bool, QString> const result = pHost->mmcpServer->ping(target);
-
+    const auto result = pHost->mmcpServer->ping(target);
     if (!result.first) {
         return warnArgumentValue(L, __func__, result.second.toUtf8().constData());
     }
@@ -239,8 +229,7 @@ int TLuaInterpreter::chatPeek(lua_State* L)
         pHost->initMMCPServer();
     }
 
-    QPair<bool, QString> const result = pHost->mmcpServer->peek(target);
-
+    const auto result = pHost->mmcpServer->peek(target);
     if (!result.first) {
         return warnArgumentValue(L, __func__, result.second.toUtf8().constData());
     }
@@ -258,8 +247,7 @@ int TLuaInterpreter::chatPrivate(lua_State* L)
         pHost->initMMCPServer();
     }
 
-    QPair<bool, QString> const result = pHost->mmcpServer->chatPrivate(target);
-
+    const auto result = pHost->mmcpServer->chatPrivate(target);
     if (!result.first) {
         return warnArgumentValue(L, __func__, result.second.toUtf8().constData());
     }
@@ -277,8 +265,7 @@ int TLuaInterpreter::chatServe(lua_State* L)
         pHost->initMMCPServer();
     }
 
-    QPair<bool, QString> const result = pHost->mmcpServer->serve(target);
-
+    const auto result = pHost->mmcpServer->serve(target);
     if (!result.first) {
         return warnArgumentValue(L, __func__, result.second.toUtf8().constData());
     }
@@ -297,8 +284,7 @@ int TLuaInterpreter::chatSetGroup(lua_State* L)
         pHost->initMMCPServer();
     }
 
-    QPair<bool, QString> const result = pHost->mmcpServer->chatSetGroup(target, group);
-
+    const auto result = pHost->mmcpServer->chatSetGroup(target, group);
     if (!result.first) {
         return warnArgumentValue(L, __func__, result.second.toUtf8().constData());
     }
@@ -317,8 +303,7 @@ int TLuaInterpreter::chatSideChannel(lua_State* L)
         pHost->initMMCPServer();
     }
 
-    QPair<bool, QString> const result = pHost->mmcpServer->chatSideChannel(channel, message);
-
+    const auto result = pHost->mmcpServer->chatSideChannel(channel, message);
     if (!result.first) {
         return warnArgumentValue(L, __func__, result.second.toUtf8().constData());
     }
@@ -336,8 +321,7 @@ int TLuaInterpreter::chatSnoop(lua_State* L)
         pHost->initMMCPServer();
     }
 
-    QPair<bool, QString> const result = pHost->mmcpServer->snoop(target);
-
+    const auto result = pHost->mmcpServer->snoop(target);
     if (!result.first) {
         return warnArgumentValue(L, __func__, result.second.toUtf8().constData());
     }
@@ -361,8 +345,7 @@ int TLuaInterpreter::chatStartServer(lua_State* L)
         pHost->initMMCPServer();
     }
 
-    QPair<bool, QString> const result = pHost->mmcpServer->startServer(port);
-
+    const auto result = pHost->mmcpServer->startServer(port);
     if (!result.first) {
         return warnArgumentValue(L, __func__, result.second.toUtf8().constData());
     }
@@ -375,8 +358,7 @@ int TLuaInterpreter::chatStopServer(lua_State* L)
 {
     Host* pHost = &getHostFromLua(L);
     if (pHost->mmcpServer) {
-        QPair<bool, QString> const result = pHost->mmcpServer->stopServer();
-
+        const auto result = pHost->mmcpServer->stopServer();
         if (!result.first) {
             return warnArgumentValue(L, __func__, result.second.toUtf8().constData());
         }
@@ -395,8 +377,7 @@ int TLuaInterpreter::chatUnChat(lua_State* L)
         pHost->initMMCPServer();
     }
 
-    QPair<bool, QString> const result = pHost->mmcpServer->unChat(target);
-
+    const auto result = pHost->mmcpServer->unChat(target);
     if (!result.first) {
         return warnArgumentValue(L, __func__, result.second.toUtf8().constData());
     }


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Removes some unused "success" strings from method in that class. Also makes use of auto in many places in the `TLuaInterpreter` classes instead of explicitly (and redundantly with latter C++ standards) specifying variables assigned to that method's return value.

#### Motivation for adding to Mudlet
They were returning values that we don't use and the remainder could be written more succinctly. It was also possible to reduce the warnings that a code-analyser in Qt Creator now produces about missing direct `#include`s - which were popping up (for all sorts of things) but in this case for the explicit use of `QPair` which we can avoid by the use of `auto` to allow the compiler to deduce from the function that is called to assign value(s) to a variable.

#### Other info (issues closed, discussion etc)
I found similar things in the dlgIRC class and have a separate PR to do the same changes there - see https://github.com/Mudlet/Mudlet/pull/7172.