### PR TITLE
Improve: rename some members and methods

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2015-2023 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2015-2024 by Stephen Lyons - slysven@virginmedia.com    *
  *   Copyright (C) 2016 by Ian Adkins - ieadkins@gmail.com                 *
  *   Copyright (C) 2018 by Huadong Qi - novload@outlook.com                *
  *   Copyright (C) 2023 by Lecker Kebap - Leris@mudlet.org                 *
@@ -51,6 +51,7 @@
 #include "dlgProfilePreferences.h"
 #include "dlgIRC.h"
 #include "mudlet.h"
+#include "MMCP.h"
 #include "MMCPServer.h"
 
 #include "pre_guard.h"
@@ -331,7 +332,7 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 , mpDlgIRC(nullptr)
 , mmcpServer(nullptr)
 , mpDlgProfilePreferences(nullptr)
-, mMMCPChatPort(4050)
+, mMMCPChatPort(csDefaultMMCPHostPort)
 , mMMCPAutostartServer(false)
 , mMMCPAllowConnectionRequests(false)
 , mMMCPAllowPeekRequests(false)
@@ -1643,7 +1644,7 @@ void Host::postIrcMessage(const QString& a, const QString& b, const QString& c)
 void Host::postChatChannelMessage(const QString& from, const QString& channel, const QString& message)
 {
     TEvent event {};
-    event.mArgumentList << MMCPServer::MMCPChatSideChannelEvent;
+    event.mArgumentList << csMMCPChatSideChannelEvent;
     event.mArgumentList << from << channel << message;
     event.mArgumentTypeList << ARGUMENT_TYPE_STRING << ARGUMENT_TYPE_STRING << ARGUMENT_TYPE_STRING << ARGUMENT_TYPE_STRING;
     raiseEvent(event);

--- a/src/MMCP.h
+++ b/src/MMCP.h
@@ -1,5 +1,8 @@
+#ifndef MUDLET_MMCP_H
+#define MUDLET_MMCP_H
 /***************************************************************************
  *   Copyright (C) 2024 by John McKisson - john.mckisson@gmail.com         *
+ *   Copyright (C) 2024 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -17,12 +20,14 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef _MMCP_H_
-#define _MMCP_H_
-
 #include "pre_guard.h"
 #include <QFlags>
 #include "post_guard.h"
+
+inline static uint16_t csDefaultMMCPHostPort{4050};
+inline static QLatin1String csDefaultMMCPChatName{"Mudlet"};
+inline static QLatin1String csDefaultMMCPGroupName{"<none>"};
+inline static QLatin1String csMMCPChatSideChannelEvent{"sysChatChannelMessage"};
 
 enum MMCPChatCommand {
     NameChange = 1,
@@ -83,4 +88,4 @@ constexpr char const* BCYN = "\x1b[46m";
 constexpr char const* BWHT = "\x1b[47m";
 } // namespace AnsiColors
 
-#endif
+#endif // MUDLET_MMCP_H

--- a/src/MMCPClient.h
+++ b/src/MMCPClient.h
@@ -1,5 +1,8 @@
+#ifndef MUDLET_MMCPCLIENT_H
+#define MUDLET_MMCPCLIENT_H
 /***************************************************************************
  *   Copyright (C) 2024 by John McKisson - john.mckisson@gmail.com         *
+ *   Copyright (C) 2024 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -17,8 +20,6 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef _MMCPCLIENT_H_
-#define _MMCPCLIENT_H_
 
 #include "pre_guard.h"
 #include <QtNetwork>
@@ -45,10 +46,15 @@ class MMCPClient : public QObject
     Q_PROPERTY(bool isSnooped READ isSnooped WRITE setSnooped)
     Q_PROPERTY(bool isSnooping READ isSnooping WRITE setSnooping)
     Q_PROPERTY(int state READ state)
-    Q_PROPERTY(QString host READ host);
-    Q_PROPERTY(quint16 port READ port);
+    Q_PROPERTY(QString host READ host)
+    Q_PROPERTY(quint16 port READ port)
 
-    enum ClientState { Disconnected = 0, ConnectingIn, ConnectingOut, Connected };
+    enum ClientState {
+        Disconnected = 0,
+        ConnectingIn,
+        ConnectingOut,
+        Connected
+    };
 
 public:
     MMCPClient(Host*, MMCPServer*);
@@ -67,73 +73,79 @@ public:
 
     const QString getInfoString();
     const QString getFlagsString();
-    const QString& getVersion();
+    const QString& getVersion() const { return mPeerVersion; }
     QString host();
     quint16 port();
 
     //Property Accessors/Mutators
-    int id() { return m_id; }
-    void setId(int val) { m_id = val; }
+    int id() const { return mId; }
+    void setId(const int val) { mId = val; }
 
-    bool canSnoop() { return m_canSnoop; }
-    void setCanSnoop(bool val) { m_canSnoop = val; }
+    bool canSnoop() const { return mEnableSnooping; }
+    void setCanSnoop(const bool val) { mEnableSnooping = val; }
 
-    const QString& chatName() { return m_chatName; }
+    const QString& chatName() const { return mPeerName; }
 
-    bool isIgnored() { return m_isIgnored; }
-    void setIgnore(bool val) { m_isIgnored = val; }
+    bool isIgnored() const { return mIsIgnored; }
+    void setIgnore(const bool val) { mIsIgnored = val; }
 
-    bool isPrivate() { return m_isPrivate; }
-    void setPrivate(bool val) { m_isPrivate = val; }
+    bool isPrivate() const { return mIsPrivate; }
+    void setPrivate(const bool val) { mIsPrivate = val; }
 
-    bool isServed() { return m_isServed; }
-    void setServed(bool val) { m_isServed = val; }
+    bool isServed() const { return mIsServed; }
+    void setServed(const bool val) { mIsServed = val; }
 
-    bool isServing() { return m_isServing; }
-    void setServing(bool val) { m_isServing = val; }
+    bool isServing() const { return mIsServing; }
+    void setServing(const bool val) { mIsServing = val; }
 
-    bool isSnooped() { return m_isSnooped; }
-    void setSnooped(bool val) { m_isSnooped = val; }
+    bool isSnooped() const { return mIsSnooped; }
+    void setSnooped(const bool val) { mIsSnooped = val; }
 
-    bool isSnooping() { return m_isSnooping; }
-    void setSnooping(bool val) { m_isSnooping = val; }
+    bool isSnooping() const { return mIsSnooping; }
+    void setSnooping(const bool val) { mIsSnooping = val; }
 
-    const QString& getGroup() { return m_group; }
+    const QString& getGroup() const { return mGroup; }
     bool setGroup(const QString&);
 
-    int state() { return m_state; }
+    ClientState state() const { return mState; }
 
-    MMCPServer* getServer() { return server; }
+    MMCPServer* getServer() { return mpMMCPServer; }
 
 signals:
-    void clientDisconnected(MMCPClient*);
+    void signal_clientDisconnected(MMCPClient*);
 
 private slots:
-    void slotConnected();
-    void slotDisconnected();
-    void slotReadData();
-    void slotDisplayError(QAbstractSocket::SocketError socketError);
+    void slot_connected();
+    void slot_disconnected();
+    void slot_readData();
+    void slot_displayError(QAbstractSocket::SocketError socketError);
 
 private:
-    int m_id;
-    bool m_canSnoop;
-    QString m_chatName;
-    bool m_isIgnored;
-    bool m_isPrivate;
-    bool m_isServed;
-    bool m_isServing;  // do we actually know this?
-    bool m_isSnooped;  // are we snooping THEM?
-    bool m_isSnooping; // is this client snooping US?
-    int m_state;
-    QString m_host;
-    quint16 m_port;
-    QByteArray buffer;
-    QString m_group;
+    Host* mpHost = nullptr;
+    MMCPServer* mpMMCPServer = nullptr;
+    ClientState mState = Disconnected;
+    QTcpSocket mTcpSocket;
+    QString mGroup = csDefaultMMCPGroupName;
+    int mId;
+    bool mEnableSnooping = false;
+    QString mPeerName;
+    //auto ignore or ignorelist match?
+    bool mIsIgnored = false;
+    //auto private or privatelist match?
+    bool mIsPrivate = false;
+    //auto serve or servelist match?
+    bool mIsServed = false;
+    // do we actually know this?
+    bool mIsServing = false;
+    // are we snooping THEM?
+    bool mIsSnooped = false;
+    // is this client snooping US?
+    bool mIsSnooping = false;
+    QString mPeerAddress;
+    quint16 mPeerPort;
+    QByteArray mPeerBuffer;
+    QString mPeerVersion;
 
-    QTcpSocket tcpSocket;
-    Host* mpHost;
-    MMCPServer* server;
-    QString version;
 
     void sendVersion();
     void handleConnectedState(const QByteArray&);
@@ -153,4 +165,4 @@ private:
     void handleIncomingSnoopData(const char*, quint16);
     void handleIncomingSideChannelData(const QString&);
 };
-#endif
+#endif // MUDLET_MMCPCLIENT_H

--- a/src/MMCPServer.cpp
+++ b/src/MMCPServer.cpp
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2024 by John McKisson - john.mckisson@gmail.com         *
+ *   Copyright (C) 2024 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -35,12 +36,12 @@
 #include <QVariant>
 #include "post_guard.h"
 
-MMCPServer::MMCPServer(Host* pHost) : QTcpServer(), mpHost(pHost), snoopCount(0)
+MMCPServer::MMCPServer(Host* pHost)
+: QTcpServer()
+, mpHost(pHost)
+, mChatName(pHost->getMMCPChatName())
 {
-    m_chatName = pHost->getMMCPChatName();
-};
-
-MMCPServer::~MMCPServer() {}
+}
 
 /**
  * Handle an incoming connection, create an MMCPClient and set its state
@@ -48,9 +49,9 @@ MMCPServer::~MMCPServer() {}
  */
 void MMCPServer::incomingConnection(qintptr socketDescriptor)
 {
-    MMCPClient* client = new MMCPClient(mpHost, this);
-    if (!client->incoming(socketDescriptor)) {
-        client->deleteLater();
+    MMCPClient* pClient = new MMCPClient(mpHost, this);
+    if (!pClient->incoming(socketDescriptor)) {
+        pClient->deleteLater();
     }
 }
 
@@ -59,7 +60,7 @@ void MMCPServer::incomingConnection(qintptr socketDescriptor)
  */
 void MMCPServer::receiveFromPlayer(std::string& str)
 {
-    if (snoopCount > 0) {
+    if (mSnoopCount > 0) {
         sendSnoopData(str);
     }
 }
@@ -80,7 +81,7 @@ void MMCPServer::sendSnoopData(std::string& line)
                                     .arg(QString::fromStdString(line))
                                     .arg(static_cast<char>(End));
 
-    QListIterator<MMCPClient*> it(clients);
+    QListIterator<MMCPClient*> it(mPeersList);
     while (it.hasNext()) {
         MMCPClient* cl = it.next();
         if (cl->isSnooping()) {
@@ -95,30 +96,32 @@ void MMCPServer::sendSnoopData(std::string& line)
  */
 MMCPClient* MMCPServer::clientByNameOrId(const QVariant& arg)
 {
-    MMCPClient* client = nullptr;
+    MMCPClient* pClient = nullptr;
 
     bool ok;
     int id = arg.toInt(&ok);
 
     if (!ok) {
-        const QString lowerName = arg.toString().toLower();
-
-        QListIterator<MMCPClient*> it(clients);
+        // Arg does NOT appear to be an integer so it is probably a name:
+        const QString name = arg.toString();
+        QListIterator<MMCPClient*> it(mPeersList);
         while (it.hasNext()) {
             MMCPClient* cl = it.next();
-            if (cl->chatName().toLower() == lowerName) {
-                client = cl;
+            if (!name.compare(cl->chatName(), Qt::CaseInsensitive)) {
+                pClient = cl;
                 break;
             }
         }
 
     } else {
-        if (id > 0 && id <= clients.size()) {
-            client = clients[id - 1];
+        // It is an integer
+        if (id > 0 && id <= mPeersList.size()) {
+            // And it is in range
+            pClient = mPeersList[id - 1];
         }
     }
 
-    return client;
+    return pClient;
 }
 
 /**
@@ -137,7 +140,7 @@ QPair<bool, QString> MMCPServer::call(const QString& line)
         return {false, qsl("must specify a host")};
     }
 
-    quint16 port = 4050;
+    quint16 port = csDefaultMMCPHostPort;
 
     if (n == 2) {
         bool ok;
@@ -154,19 +157,19 @@ QPair<bool, QString> MMCPServer::call(const QString& line)
  */
 QPair<bool, QString> MMCPServer::call(const QString& host, int port)
 {
-    MMCPClient* client = nullptr;
+    MMCPClient* pClient = nullptr;
 
-    QListIterator<MMCPClient*> it(clients);
+    QListIterator<MMCPClient*> it(mPeersList);
     while (it.hasNext()) {
         MMCPClient* cl = it.next();
-        if (cl->host() == host && client->port() == port) {
-            client = cl;
+        if (cl->host() == host && pClient->port() == port) {
+            pClient = cl;
             break;
         }
     }
 
     //Check if we're already connected to this person
-    if (client != nullptr) {
+    if (pClient) {
         const QString infoMsg = tr("[ CHAT ]  - Already connected to %1:%2.").arg(host).arg(port);
         mpHost->postMessage(infoMsg);
 
@@ -176,9 +179,9 @@ QPair<bool, QString> MMCPServer::call(const QString& host, int port)
     const QString infoMsg = tr("[ CHAT ]  - Connecting to %1:%2...").arg(host).arg(port);
     mpHost->postMessage(infoMsg);
 
-    client = new MMCPClient(mpHost, this);
+    pClient = new MMCPClient(mpHost, this);
 
-    client->tryConnect(host, port);
+    pClient->tryConnect(host, port);
 
     return {true, QString()};
 }
@@ -189,18 +192,18 @@ QPair<bool, QString> MMCPServer::call(const QString& host, int port)
  */
 QPair<bool, QString> MMCPServer::chat(const QVariant& target, const QString& msg)
 {
-    MMCPClient* client = clientByNameOrId(target);
+    MMCPClient* pClient = clientByNameOrId(target);
 
-    if (client != nullptr) {
+    if (pClient) {
         const QString outMsg = QString("%1%2 chats to you, '%3'\n%4")
                                         .arg(static_cast<char>(TextPersonal))
-                                        .arg(m_chatName)
+                                        .arg(mChatName)
                                         .arg(msg)
                                         .arg(static_cast<char>(End));
 
-        client->writeData(outMsg);
+        pClient->writeData(outMsg);
 
-        clientMessage(QString("You chat to %1, '%2'").arg(client->chatName()).arg(msg));
+        clientMessage(QString("You chat to %1, '%2'").arg(pClient->chatName()).arg(msg));
         return {true, QString()};
     }
 
@@ -215,17 +218,17 @@ QPair<bool, QString> MMCPServer::chat(const QVariant& target, const QString& msg
  */
 QPair<bool, QString> MMCPServer::chatAll(const QString& msg)
 {
-    if (clients.isEmpty()) {
+    if (mPeersList.isEmpty()) {
         return {false, qsl("no connected clients")};
     }
 
     QString outMsg = QString("%1\n%2 chats to everybody, '%3'%4%5")
                             .arg(static_cast<char>(TextEveryone))
-                            .arg(m_chatName).arg(msg)
-							.arg(mpHost->mmcpShouldAppendNewlineAfterOutgoingChats() ? "\n" : "")
+                            .arg(mChatName).arg(msg)
+                            .arg(mpHost->mmcpShouldAppendNewlineAfterOutgoingChats() ? "\n" : "")
                             .arg(static_cast<char>(End));
 
-    QListIterator<MMCPClient*> it(clients);
+    QListIterator<MMCPClient*> it(mPeersList);
     while (it.hasNext()) {
         MMCPClient* cl = it.next();
         cl->writeData(outMsg);
@@ -241,7 +244,7 @@ QPair<bool, QString> MMCPServer::chatAll(const QString& msg)
  */
 QPair<bool, QString> MMCPServer::chatGroup(const QString& group, const QString& message)
 {
-    if (clients.isEmpty()) {
+    if (mPeersList.isEmpty()) {
         return {false, qsl("no connected clients")};
     }
 
@@ -250,12 +253,12 @@ QPair<bool, QString> MMCPServer::chatGroup(const QString& group, const QString& 
     QString outMsg = QString("%1%2\n%3%4 chats to the group, '%5'\n%6")
                             .arg(static_cast<char>(TextGroup))
                             .arg(group, -15)
-                            .arg(m_chatName)
+                            .arg(mChatName)
                             .arg(FBLDRED)
                             .arg(message)
                             .arg(static_cast<char>(End));
 
-    QListIterator<MMCPClient*> it(clients);
+    QListIterator<MMCPClient*> it(mPeersList);
     while (it.hasNext()) {
         MMCPClient* cl = it.next();
         if (cl->getGroup() == group) {
@@ -283,18 +286,18 @@ QPair<bool, QString> MMCPServer::chatList()
     strMessage += "     ==================== ==================== ===== =============== ======== ================\n";
 
     int i = 1;
-    QListIterator<MMCPClient*> it(clients);
+    QListIterator<MMCPClient*> it(mPeersList);
     while (it.hasNext()) {
-        MMCPClient* client = it.next();
+        MMCPClient* pClient = it.next();
         strMessage.append(QString("%1%2:%3 %4 %5\n")
                             .arg(FBLDWHT)
                             .arg(i++, 3)
                             .arg(RST)
-                            .arg(client->getInfoString())
-                            .arg(client->getVersion()));
+                            .arg(pClient->getInfoString())
+                            .arg(pClient->getVersion()));
     }
 
-	strMessage.append("%1\n").arg(RST);
+    strMessage.append("%1\n").arg(RST);
     strMessage += "Flags:  A - Allow Commands, F - Firewall, I - Ignore,  P - Private   n - Allow Snooping\n";
     strMessage += "        N - Being Snooped,  S - Serving,  T - Allows File Transfers, X - Serve Exclude\n";
 
@@ -310,13 +313,13 @@ QPair<bool, QString> MMCPServer::chatName(const QString& name)
 {
     setChatName(name);
 
-    if (!clients.isEmpty()) {
+    if (!mPeersList.isEmpty()) {
         const QString outMsg = QString("%1%2%3")
                                 .arg(static_cast<char>(NameChange))
                                 .arg(name)
                                 .arg(static_cast<char>(End));
 
-        QListIterator<MMCPClient*> it(clients);
+        QListIterator<MMCPClient*> it(mPeersList);
         while (it.hasNext()) {
             MMCPClient* cl = it.next();
             cl->writeData(outMsg);
@@ -334,7 +337,7 @@ QPair<bool, QString> MMCPServer::chatName(const QString& name)
  */
 QPair<bool, QString> MMCPServer::chatSideChannel(const QString& channel, const QString& msg)
 {
-    if (clients.isEmpty()) {
+    if (mPeersList.isEmpty()) {
         return {false, qsl("no connected clients")};
     }
 
@@ -344,11 +347,11 @@ QPair<bool, QString> MMCPServer::chatSideChannel(const QString& channel, const Q
                             .arg(msg)
                             .arg(static_cast<char>(End));
 
-    QListIterator<MMCPClient*> it(clients);
+    QListIterator<MMCPClient*> it(mPeersList);
     while (it.hasNext()) {
         MMCPClient* cl = it.next();
         //Only send to Mudlet clients
-        if (cl->getVersion().contains("Mudlet")) {
+        if (cl->getVersion().contains("Mudlet", Qt::CaseInsensitive)) {
             cl->writeData(outMsg);
         }
     }
@@ -363,7 +366,7 @@ QPair<bool, QString> MMCPServer::chatSideChannel(const QString& channel, const Q
  */
 QPair<bool, QString> MMCPServer::chatRaw(const QString& msg)
 {
-    if (clients.isEmpty()) {
+    if (mPeersList.isEmpty()) {
         return {false, qsl("no connected clients")};
     }
 
@@ -372,7 +375,7 @@ QPair<bool, QString> MMCPServer::chatRaw(const QString& msg)
                             .arg(msg)
                             .arg(static_cast<char>(End));
 
-    QListIterator<MMCPClient*> it(clients);
+    QListIterator<MMCPClient*> it(mPeersList);
     while (it.hasNext()) {
         MMCPClient* cl = it.next();
         cl->writeData(outMsg);
@@ -389,19 +392,19 @@ QPair<bool, QString> MMCPServer::chatRaw(const QString& msg)
  */
 QPair<bool, QString> MMCPServer::chatSetGroup(const QVariant& target, const QString& group)
 {
-    MMCPClient* client = clientByNameOrId(target);
+    MMCPClient* pClient = clientByNameOrId(target);
 
-    if (client != nullptr) {
-        const QString currentGroup = client->getGroup();
-        bool assigned = client->setGroup(group);
+    if (pClient) {
+        const QString currentGroup = pClient->getGroup();
+        bool assigned = pClient->setGroup(group);
 
         QString infoMsg;
         if (assigned) {
             infoMsg = tr("[ CHAT ]  - Assigned '%1' to group '%2'.")
-                    .arg(m_chatName).arg(group);
+                              .arg(pClient->chatName(), group);
         } else {
             infoMsg = tr("[ CHAT ]  - Removed '%1' from group '%2'.")
-                    .arg(m_chatName).arg(currentGroup);
+                              .arg(pClient->chatName(), currentGroup);
         }
 
         mpHost->postMessage(infoMsg);
@@ -418,7 +421,7 @@ QPair<bool, QString> MMCPServer::chatSetGroup(const QVariant& target, const QStr
  */
 QPair<bool, QString> MMCPServer::emoteAll(const QString& msg)
 {
-    if (clients.isEmpty()) {
+    if (mPeersList.isEmpty()) {
         return {false, qsl("no connected clients")};
     }
 
@@ -427,7 +430,7 @@ QPair<bool, QString> MMCPServer::emoteAll(const QString& msg)
                             .arg(msg)
                             .arg(static_cast<char>(End));
 
-    QListIterator<MMCPClient*> it(clients);
+    QListIterator<MMCPClient*> it(mPeersList);
     while (it.hasNext()) {
         MMCPClient* cl = it.next();
         cl->writeData(outMsg);
@@ -443,17 +446,17 @@ QPair<bool, QString> MMCPServer::emoteAll(const QString& msg)
  */
 QPair<bool, QString> MMCPServer::ignore(const QString& target)
 {
-    MMCPClient* client = clientByNameOrId(target);
+    MMCPClient* pClient = clientByNameOrId(target);
 
-    if (client != nullptr) {
-        if (client->isIgnored()) {
-            const QString infoMsg = tr("[ CHAT ]  - You are no longer ignoring %1.").arg(client->chatName());
+    if (pClient) {
+        if (pClient->isIgnored()) {
+            const QString infoMsg = tr("[ CHAT ]  - You are no longer ignoring %1.").arg(pClient->chatName());
             mpHost->postMessage(infoMsg);
         } else {
-            const QString infoMsg = tr("[ CHAT ]  - You are now ignoring %1.").arg(client->chatName());
+            const QString infoMsg = tr("[ CHAT ]  - You are now ignoring %1.").arg(pClient->chatName());
             mpHost->postMessage(infoMsg);
         }
-        client->setIgnore(!client->isIgnored());
+        pClient->setIgnore(!pClient->isIgnored());
         return {true, QString()};
     }
 
@@ -468,10 +471,10 @@ QPair<bool, QString> MMCPServer::ignore(const QString& target)
  */
 QPair<bool, QString> MMCPServer::ping(const QVariant& target)
 {
-    MMCPClient* client = clientByNameOrId(target);
+    MMCPClient* pClient = clientByNameOrId(target);
 
-    if (client != nullptr) {
-        client->sendPingRequest();
+    if (pClient) {
+        pClient->sendPingRequest();
         return {true, QString()};
     }
 
@@ -483,10 +486,10 @@ QPair<bool, QString> MMCPServer::ping(const QVariant& target)
  */
 QPair<bool, QString> MMCPServer::peek(const QVariant& target)
 {
-    MMCPClient* client = clientByNameOrId(target);
+    MMCPClient* pClient = clientByNameOrId(target);
 
-    if (client != nullptr) {
-        client->sendPeekRequest();
+    if (pClient) {
+        pClient->sendPeekRequest();
         return {true, QString()};
     }
 
@@ -498,16 +501,16 @@ QPair<bool, QString> MMCPServer::peek(const QVariant& target)
  */
 QPair<bool, QString> MMCPServer::chatPrivate(const QVariant& target)
 {
-    MMCPClient* client = clientByNameOrId(target);
+    MMCPClient* pClient = clientByNameOrId(target);
 
-    if (client != nullptr) {
-        if (client->isPrivate()) {
-            client->setPrivate(false);
-            const QString infoMsg = tr("[ CHAT ]  - %1 is no longer private.").arg(client->chatName());
+    if (pClient) {
+        if (pClient->isPrivate()) {
+            pClient->setPrivate(false);
+            const QString infoMsg = tr("[ CHAT ]  - %1 is no longer private.").arg(pClient->chatName());
             mpHost->postMessage(infoMsg);
         } else {
-            client->setPrivate(true);
-            const QString infoMsg = tr("[ CHAT ]  - %1 is now set as private.").arg(client->chatName());
+            pClient->setPrivate(true);
+            const QString infoMsg = tr("[ CHAT ]  - %1 is now set as private.").arg(pClient->chatName());
             mpHost->postMessage(infoMsg);
         }
         return {true, QString()};
@@ -521,21 +524,21 @@ QPair<bool, QString> MMCPServer::chatPrivate(const QVariant& target)
  */
 QPair<bool, QString> MMCPServer::serve(const QVariant& target)
 {
-    MMCPClient* client = clientByNameOrId(target);
+    MMCPClient* pClient = clientByNameOrId(target);
 
-    if (client != nullptr) {
-        if (client->isServed()) {
-            client->setServed(false);
-            client->sendMessage(QString("<CHAT> You are no longer being served by %1.").arg(m_chatName));
+    if (pClient) {
+        if (pClient->isServed()) {
+            pClient->setServed(false);
+            pClient->sendMessage(QString("<CHAT> You are no longer being served by %1.").arg(mChatName));
 
-            const QString infoMsg = tr("[ CHAT ]  - You are no longer serving %1.").arg(client->chatName());
+            const QString infoMsg = tr("[ CHAT ]  - You are no longer serving %1.").arg(pClient->chatName());
             mpHost->postMessage(infoMsg);
 
         } else {
-            client->setServed(true);
-            client->sendMessage(QString("<CHAT> You are now being served by %1.").arg(m_chatName));
+            pClient->setServed(true);
+            pClient->sendMessage(QString("<CHAT> You are now being served by %1.").arg(mChatName));
 
-            const QString infoMsg = tr("[ CHAT ]  - You are now serving %1.").arg(client->chatName());
+            const QString infoMsg = tr("[ CHAT ]  - You are now serving %1.").arg(pClient->chatName());
             mpHost->postMessage(infoMsg);
         }
 
@@ -558,7 +561,6 @@ QPair<bool, QString> MMCPServer::startServer(quint16 port)
 
     const QString infoMsg = tr("[ CHAT ]  - Started server on port %1.").arg(port);
     mpHost->postMessage(infoMsg);
-    emit serverStarted(port);
 
     return {true, QString()};
 }
@@ -582,22 +584,22 @@ QPair<bool, QString> MMCPServer::stopServer()
  */
 QPair<bool, QString> MMCPServer::allowSnoop(const QVariant& target)
 {
-    MMCPClient* client = clientByNameOrId(target);
+    MMCPClient* pClient = clientByNameOrId(target);
 
-    if (client != nullptr) {
-        if (client->canSnoop()) {
-            client->setCanSnoop(false);
-            client->setSnooped(false);
-            client->sendMessage(QString("<CHAT> You are no longer allowed to snoop %1.").arg(m_chatName));
+    if (pClient) {
+        if (pClient->canSnoop()) {
+            pClient->setCanSnoop(false);
+            pClient->setSnooped(false);
+            pClient->sendMessage(QString("<CHAT> You are no longer allowed to snoop %1.").arg(mChatName));
 
-            const QString infoMsg = tr("[ CHAT ]  - %1 is no longer allowed to snoop you.").arg(client->chatName());
+            const QString infoMsg = tr("[ CHAT ]  - %1 is no longer allowed to snoop you.").arg(pClient->chatName());
             mpHost->postMessage(infoMsg);
 
         } else {
-            client->setCanSnoop(true);
-            client->sendMessage(QString("<CHAT> You are now allowed to snoop %1.").arg(m_chatName));
+            pClient->setCanSnoop(true);
+            pClient->sendMessage(QString("<CHAT> You are now allowed to snoop %1.").arg(mChatName));
 
-            const QString infoMsg = tr("[ CHAT ]  - %1 can now snoop you.").arg(client->chatName());
+            const QString infoMsg = tr("[ CHAT ]  - %1 can now snoop you.").arg(pClient->chatName());
             mpHost->postMessage(infoMsg);
         }
 
@@ -612,13 +614,13 @@ QPair<bool, QString> MMCPServer::allowSnoop(const QVariant& target)
  */
 QPair<bool, QString> MMCPServer::snoop(const QVariant& target)
 {
-    MMCPClient* client = clientByNameOrId(target);
+    MMCPClient* pClient = clientByNameOrId(target);
 
-    if (client != NULL) {
-        if (client->isSnooped()) {
-            client->setSnooped(false);
+    if (pClient) {
+        if (pClient->isSnooped()) {
+            pClient->setSnooped(false);
         } else {
-            client->snoop();
+            pClient->snoop();
         }
 
         return {true, QString()};
@@ -632,10 +634,10 @@ QPair<bool, QString> MMCPServer::snoop(const QVariant& target)
  */
 QPair<bool, QString> MMCPServer::unChat(const QVariant& target)
 {
-    MMCPClient* client = clientByNameOrId(target);
+    MMCPClient* pClient = clientByNameOrId(target);
 
-    if (client != NULL) {
-        client->disconnect();
+    if (pClient) {
+        pClient->disconnect();
         return {true, QString()};
     }
 
@@ -643,17 +645,15 @@ QPair<bool, QString> MMCPServer::unChat(const QVariant& target)
 }
 
 
-void MMCPServer::addConnectedClient(MMCPClient* client)
+void MMCPServer::addConnectedClient(MMCPClient* pClient)
 {
-    clients.append(client);
-    client->setId(clients.indexOf(client));
-    emit clientConnected(client);
+    mPeersList.append(pClient);
+    pClient->setId(mPeersList.indexOf(pClient));
 }
 
-void MMCPServer::slotClientDisconnected(MMCPClient* client)
+void MMCPServer::slot_clientDisconnected(MMCPClient* pClient)
 {
-    clients.removeOne(client);
-    emit clientDisconnected(client);
+    mPeersList.removeOne(pClient);
 }
 
 
@@ -693,7 +693,7 @@ void MMCPServer::snoopMessage(const std::string& message)
 
 void MMCPServer::sendAll(QString& msg)
 {
-    QListIterator<MMCPClient*> it(clients);
+    QListIterator<MMCPClient*> it(mPeersList);
     while (it.hasNext()) {
         MMCPClient* cl = it.next();
         cl->writeData(msg);
@@ -703,15 +703,15 @@ void MMCPServer::sendAll(QString& msg)
 /**
  * Send our public connections to everyone (not the client that requested)
  */
-void MMCPServer::sendPublicConnections(MMCPClient* client)
+void MMCPServer::sendPublicConnections(MMCPClient* pClient)
 {
     QString list;
 
-    QListIterator<MMCPClient*> it(clients);
+    QListIterator<MMCPClient*> it(mPeersList);
     while (it.hasNext()) {
         MMCPClient* cl = it.next();
 
-        if (cl != client && !cl->isPrivate()) {
+        if (cl != pClient && !cl->isPrivate()) {
             list.append(QString("%1,%2")
                         .arg(cl->host()).arg(cl->port())
                         .arg(it.hasNext() ? "," : ""));
@@ -724,22 +724,22 @@ void MMCPServer::sendPublicConnections(MMCPClient* client)
                                 .arg(list)
                                 .arg(static_cast<char>(End));
 
-        client->writeData(cmdStr);
+        pClient->writeData(cmdStr);
     }
 }
 
 /**
  * Send a peek list of our public connections to everyone (not the client that requested)
  */
-void MMCPServer::sendPublicPeek(MMCPClient* client)
+void MMCPServer::sendPublicPeek(MMCPClient* pClient)
 {
     QString list;
 
-    QListIterator<MMCPClient*> it(clients);
+    QListIterator<MMCPClient*> it(mPeersList);
     while (it.hasNext()) {
         MMCPClient* cl = it.next();
 
-        if (cl != client && !cl->isPrivate()) {
+        if (cl != pClient && !cl->isPrivate()) {
             list.append(QString("%1~%2~%3%4")
                         .arg(cl->host()).arg(cl->port()).arg(cl->chatName())
                         .arg(it.hasNext() ? "~" : ""));
@@ -752,26 +752,26 @@ void MMCPServer::sendPublicPeek(MMCPClient* client)
 								.arg(list)
 								.arg(static_cast<char>(End));
 
-        client->writeData(cmdStr);
+        pClient->writeData(cmdStr);
     } else {
-        client->sendMessage(QString("<CHAT> %1 doesn't have any other connections").arg(m_chatName));
+        pClient->sendMessage(QString("<CHAT> %1 doesn't have any other connections").arg(mChatName));
     }
 }
 
 /**
  * Forward message to all clients.
  */
-void MMCPServer::sendServedMessage(MMCPClient* client, const QString& msg)
+void MMCPServer::sendServedMessage(MMCPClient* pClient, const QString& msg)
 {
     const QString cmdStr = QString("%1%2%3")
                             .arg(static_cast<char>(TextEveryone))
                             .arg(msg)
                             .arg(static_cast<char>(End));
 
-    QListIterator<MMCPClient*> it(clients);
+    QListIterator<MMCPClient*> it(mPeersList);
     while (it.hasNext()) {
         MMCPClient* cl = it.next();
-        if (cl != client) {
+        if (cl != pClient) {
             cl->writeData(cmdStr);
         }
     }
@@ -780,17 +780,17 @@ void MMCPServer::sendServedMessage(MMCPClient* client, const QString& msg)
 /**
  * Forward message to all served clients.
  */
-void MMCPServer::sendMessageToServed(MMCPClient* client, const QString& msg)
+void MMCPServer::sendMessageToServed(MMCPClient* pClient, const QString& msg)
 {
     const QString cmdStr = QString("%1%2%3")
                             .arg(static_cast<char>(TextEveryone))
                             .arg(msg)
                             .arg(static_cast<char>(End));
 
-    QListIterator<MMCPClient*> it(clients);
+    QListIterator<MMCPClient*> it(mPeersList);
     while (it.hasNext()) {
         MMCPClient* cl = it.next();
-        if (cl != client && cl->isServed()) {
+        if (cl != pClient && cl->isServed()) {
             cl->writeData(cmdStr);
         }
     }
@@ -801,7 +801,7 @@ void MMCPServer::sendMessageToServed(MMCPClient* client, const QString& msg)
  */
 void MMCPServer::setChatName(const QString& val)
 {
-    m_chatName = val;
+    mChatName = val;
     // set the host chatname so it gets saved in the profile
-    mpHost->setMMCPChatName(m_chatName);
+    mpHost->setMMCPChatName(mChatName);
 }

--- a/src/MMCPServer.h
+++ b/src/MMCPServer.h
@@ -1,8 +1,8 @@
-#ifndef _MMCPSERVER_H_
-#define _MMCPSERVER_H_
-
+#ifndef MUDLET_MCPSERVER_H
+#define MUDLET_MMCPSERVER_H
 /***************************************************************************
  *   Copyright (C) 2024 by John McKisson - john.mckisson@gmail.com         *
+ *   Copyright (C) 2024 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -37,12 +37,8 @@ class MMCPServer : public QTcpServer
     Q_PROPERTY(QString getChatName READ getChatName WRITE setChatName)
 
 public:
-    inline static int MMCPDefaultHostPort = 4050;
-    inline static QString DefaultMMCPChatName = qsl("MudletMMCP");
-    inline static QLatin1String MMCPChatSideChannelEvent = QLatin1String("sysChatChannelMessage");
-
     explicit MMCPServer(Host*);
-    ~MMCPServer();
+    ~MMCPServer() = default;
 
     void receiveFromPlayer(std::string&);
 
@@ -72,10 +68,10 @@ public:
     void clientMessage(const QString&);
     void snoopMessage(const std::string&);
 
-    QList<MMCPClient*>* getClients() { return &clients; }
+    QList<MMCPClient*>* getClients() { return &mPeersList; }
 
-    void decrementSnoopCount() { snoopCount--; }
-    void incrementSnoopCount() { snoopCount++; }
+    void decrementSnoopCount() { --mSnoopCount; }
+    void incrementSnoopCount() { ++mSnoopCount; }
 
     void sendPublicConnections(MMCPClient*);
     void sendPublicPeek(MMCPClient*);
@@ -85,33 +81,26 @@ public:
     void addConnectedClient(MMCPClient*);
     void disconnectClient(MMCPClient*);
 
-    QString getChatName() const { return m_chatName; }
+    QString getChatName() const { return mChatName; }
     void setChatName(const QString&);
 
-signals:
-    void serverStarted(int);
-    void clientConnected(MMCPClient*);
-    void clientDisconnected(MMCPClient*);
-    void printStatusMessage(const QString&);
 
 public slots:
-    void slotClientDisconnected(MMCPClient*);
+    void slot_clientDisconnected(MMCPClient*);
+
 
 protected:
     void incomingConnection(qintptr) override;
 
+
 private:
-    Host* mpHost = nullptr;
-    QString m_chatName;
-
-    QList<MMCPClient*> clients;
-    int snoopCount;
-
-    void sendSnoopData(std::string&);
-
     MMCPClient* clientByNameOrId(const QVariant&);
-
+    void sendSnoopData(std::string&);
     void sendAll(QString&);
-};
 
-#endif
+    Host* mpHost = nullptr;
+    QString mChatName;
+    QList<MMCPClient*> mPeersList;
+    int mSnoopCount = 0;
+};
+#endif // MUDLET_MCPSERVER_H

--- a/src/TLuaInterpreterMMCP.cpp
+++ b/src/TLuaInterpreterMMCP.cpp
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2024 by John McKisson - john.mckisson@gmail.com         *
+ *   Copyright (C) 2024 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -21,6 +22,7 @@
 // for convenience and to keep TLuaInterpreter.cpp size reasonable
 
 #include "Host.h"
+#include "MMCP.h"
 #include "MMCPServer.h"
 #include "TLuaInterpreter.h"
 
@@ -82,11 +84,11 @@ int TLuaInterpreter::chatAllowSnoop(lua_State* L)
 int TLuaInterpreter::chatCall(lua_State* L)
 {
     const QString host = getVerifiedString(L, __func__, 1, "host");
-    int port = MMCPServer::MMCPDefaultHostPort;
+    int port = csDefaultMMCPHostPort;
 
     const int n = lua_gettop(L);
     if (n > 1) {
-        port = getVerifiedInt(L, __func__, 2, "port number {default = 4050}", true);
+        port = getVerifiedInt(L, __func__, 2, qsl("port number {default = %1}").arg(csDefaultMMCPHostPort).toUtf8().constData(), true);
         if (port > 65535 || port < 1) {
             return warnArgumentValue(L, __func__, qsl("invalid port number %1 given, if supplied it must be in range 1 to 65535").arg(port));
         }
@@ -332,9 +334,9 @@ int TLuaInterpreter::chatSnoop(lua_State* L)
 
 int TLuaInterpreter::chatStartServer(lua_State* L)
 {
-    int port = 4050;
+    int port = csDefaultMMCPHostPort;
     if (lua_gettop(L) > 0) {
-        port = getVerifiedInt(L, __func__, 1, "port number {default = 4050}", true);
+        port = getVerifiedInt(L, __func__, 1, qsl("port number {default = %1}").arg(csDefaultMMCPHostPort).toUtf8().constData(), true);
         if (port > 65535 || port < 1) {
             return warnArgumentValue(L, __func__, qsl("invalid port number %1 given, if supplied it must be in range 1 to 65535").arg(port));
         }

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2014, 2016-2018, 2020-2023 by Stephen Lyons             *
+ *   Copyright (C) 2014, 2016-2018, 2020-2024 by Stephen Lyons             *
  *                                               - slysven@virginmedia.com *
  *   Copyright (C) 2016 by Ian Adkins - ieadkins@gmail.com                 *
  *                                                                         *
@@ -34,6 +34,7 @@
 #include "dlgMapper.h"
 #include "dlgTriggerEditor.h"
 #include "edbee/views/texteditorscrollarea.h"
+#include "MMCP.h"
 #include "MMCPServer.h"
 
 #include "pre_guard.h"
@@ -249,7 +250,8 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pParentWidget, Host* pHost
                                              "<li><b>Partly checked</b> <i>(Default) 'auto'</i> = Use the setting that the system provides.</li></ul></p>"
                                              "<p><i>This setting is only processed when individual menus are created and changes may not "
                                              "propagate everywhere until Mudlet is restarted.</i></p>"));
-
+    lineEdit_mmcpPort->setPlaceholderText(QString::number(csDefaultMMCPHostPort));
+    lineEdit_mmcpChatName->setPlaceholderText(csDefaultMMCPChatName);
 
     connect(checkBox_showSpacesAndTabs, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_changeShowSpacesAndTabs);
     connect(checkBox_showLineFeedsAndParagraphs, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_changeShowLineFeedsAndParagraphs);
@@ -3085,7 +3087,7 @@ void dlgProfilePreferences::slot_saveAndClose()
         pHost->mMMCPChatName = lineEdit_mmcpChatName->text().trimmed();
         bool ok;
         quint16 port = lineEdit_mmcpPort->text().toUShort(&ok);
-        pHost->mMMCPChatPort = ok ? port : MMCPServer::MMCPDefaultHostPort;
+        pHost->mMMCPChatPort = ok ? port : csDefaultMMCPHostPort;
         
         pHost->mMMCPAutostartServer = checkBox_mmcpAutostartServer->isChecked();
         pHost->mMMCPAllowConnectionRequests = checkBox_mmcpAllowConnReq->isChecked();

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -3138,9 +3138,6 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="toolTip">
              <string>Port to use when connecting to another client without specifying a port along with the IP address. This is also the default port that listened for incoming connections when running a local server.</string>
             </property>
-            <property name="text">
-             <string>4050</string>
-            </property>
            </widget>
           </item>
           <item row="1" column="5">


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Members renamed:
* `(QByteArray) MMCPClient::buffer` ==> `MMCPClient::mPeerBuffer` - we already use the `buffer` identifier for something else and this will help to avoid confusion (and help when checking where it is used).
* `(bool) MMCPClient::m_canSnoop` ==> `MMCPClient::mEnableSnooping`
* `(QString) MMCPClient::m_chatName` ==> `(QString) MMCPClient::mPeerName` changed so that it is different from `(QString) MMCPServer::mchatName`...
* `(QString) MMCPClient::m_group` ==> `(QString) MMCPClient::mGroup`
* `(QString) MMCPClient::m_host` ==> `MMCPClient::mPeerAddress` - we use `host`, `pHost` and `mpHost` a lot elsewhere when talking about MUD Servers, having another similar `mHost` variable name could be a bit confusing.
* `(int) MMCPCLient::m_id` ==> `MMCPCLient::mId`
* `(bool) MMCPCLient::m_isIgnored` ==> `MMCPCLient::mIsIgnored`
* `(bool) MMCPCLient::m_isPrivate` ==> `MMCPCLient::mIsPrivate`
* `(bool) MMCPCLient::m_isServed` ==> `MMCPCLient::mIsServed`
* `(bool) MMCPCLient::m_isServing` ==> `MMCPCLient::mIsServing`
* `(bool) MMCPCLient::m_isSnooped` ==> `MMCPCLient::mIsSnooped`
* `(bool) MMCPCLient::m_isSnooping` ==> `MMCPCLient::mIsSnooping`
* `(quint16) MMCPCLient::m_port` ==> `MMCPClient::mPeerPort` - similar to `m_host`, renaming this could help to avoid confusion with that of the connection to the MUD Server.
* `(int) MMCPClient::m_state` ==> `(enum ClientState) MMCPClient::mState`
* `(QTcpSocket) MMCPClient::tcpSocket` ==> `MMCPClient::mTcpSocket`
* `(MMCPServer*) MMCPClient::server` ==> `MMCPClient::mpMMCPServer`
* `(QString) MMCPClient::version` ==> `MMCPClient::mPeerVersion`
* `(inline static int) MMCPServer::MMCPDefaultHostPort` ==> `(inline static uint16_t) csMMCPDefaultHostPort`
* `(inline static QString) DefaultMMCPChatName = QStringLiteral("MudletMMCP")` ==> `(inline static QLatin1String) csDefaultMMCPChatName{"Mudlet"}`
* `(inline static QLatin1String) MMCPServer::MMCPChatSideChannelEvent` ==> `(inline static QLatin1String) csMMCPChatSideChannelEvent`
* `(QString) MMCPServer::m_chatName` ==> `(QString) MMCPServer::mChatName`
* `(QList<MMCPClient*>) MMCPServer::clients` ==> `MMCPServer::mPeersList`
* `(int) MMCPServer::snoopCount` ==> `MMCPServer::mSnoopCount`

Signals renamed:
* `(void) MMCPClient::clientDisconnected(MMCPClient*)` ==> `MMCPClient::signal_clientDisconnected(MMCPClient*)`

Signals removed - because they were not used:
* `(void) MMCPServer::serverStarted(int)`
* `(void) MMCPServer::clientConnected(MMCPClient*)`
* `(void) MMCPServer::clientDisconnected(MMCPClient*)`
* `(void) MMCPServer::printStatusMessage(const QString&)`

Slots renamed:
* `(void) MMCPClient::slotConnected()` ==> `MMCPClient::slot_connected()`
* `(void) MMCPClient::slotDisconnected()` ==> `MMCPClient::slot_disconnected()`
* `(void) MMCPClient::slotDisplayError(QAbstractSocket::SocketError)` ==> `MMCPClient::slot_displayError(QAbstractSocket::SocketError)`
* `(void) MMCPClient::slotReadData()` ==> `MMCPClient::slot_readData()`
* `(void) MMCPServer::slotClientDisconnected(MMCPClient*)` ==> `MMCPServer::slot_clientDisconnected(MMCPClient*)`

Also:
* remove a couple of bogus semi-colons (from `./src/MMCPClient.h`).
* added `(inline static QLatin1String) csDefaultMMCPGroupName{"<none>"}`
* changed some places where "magic" numbers/strings are used so that instead a named constant is used instead (so that if it needs to be changed it gets changed everywhere.
* moved constant initialisers from constructor to header files as we are trying to do elsewhere in Mudlet.
* convert some `QString`s to our `qsl(`...`)` (actually `QStringLiteral`) or `tr(`...`)` or `QLatin1String(`...`)` - more to do!
* make some QDebug() messages more detailed about where they came from.
* Rename "include-guards" in `MMCP.h`, `MMCPClient.h` and `MMCPServer.h` as they were using a leading `_` - and followed by capital letters and those are reserved:
> "All names which begin with two underscores, or an underscore and a
capital letter, are reserved for the compiler and library to use as they wish.
-- https://gcc.gnu.org/onlinedocs/cpp/System-specific-Predefined-Macros.html

#### Motivation for adding to Mudlet
Bring the MMCP branch closer to the style I am using for Mudlet.

#### Other info (issues closed, discussion etc)
None

